### PR TITLE
Pin `validit` version to v1.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         "Flask",
-        "validit[yaml]"
+        "validit[yaml]==1.3.2"
     ]
 )


### PR DESCRIPTION
Soon, validit2.0 will be released, with breaking API changes that will cause your program to stop working.
It is a good practice to pin the major version of your dependencies to avoid those errors. (: